### PR TITLE
Add exception for key error for brain.getPath()

### DIFF
--- a/collective/catalogcleanup/browser.py
+++ b/collective/catalogcleanup/browser.py
@@ -264,6 +264,8 @@ class Cleanup(BrowserView):
     def get_object_or_status(self, brain, getter='getObject'):
         try:
             brain_id = brain.getPath()
+        except KeyError:
+            return 'notfound'
         except AttributeError:
             # Probably not a real brain, but a reference.
             brain_id = brain.getId()


### PR DESCRIPTION
Without this exception we got a key error in our Plone 4.3 setup when calling the browserview @@collective-catalogcleanup
