### PR TITLE
Accept brains in reference_catalog where getObject returns None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.7 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Don't complain about brains in ``reference_catalog`` where ``getObject`` returns None.
+  This happens for content without apparent problems.  [maurits]
 
 
 1.6 (2016-08-23)

--- a/collective/catalogcleanup/browser.py
+++ b/collective/catalogcleanup/browser.py
@@ -162,6 +162,10 @@ class Cleanup(BrowserView):
                 # cleaned up by one of the other methods already.
                 ref_errors += 1
                 continue
+            if ref is None:
+                # No error, but no object either.  This can happen
+                # for references.  Let's accept it.
+                continue
             for getter in getters:
                 obj = self.get_object_or_status(ref, getter)
                 if not isinstance(obj, basestring):


### PR DESCRIPTION
This happens for content without apparent problems.