### PR TITLE
Don't look for non unique ids in the reference_catalog.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 1.7 (unreleased)
 ----------------
 
+- Don't look for non unique ids in the ``reference_catalog``.
+  It looks like it is normal there.  At least, on one Plone 4.3 site
+  the code keeps creating several new uids every time I run it.
+  [maurits]
+
 - Don't complain about brains in ``reference_catalog`` where ``getObject`` returns None.
   This happens for content without apparent problems.  [maurits]
 

--- a/collective/catalogcleanup/browser.py
+++ b/collective/catalogcleanup/browser.py
@@ -54,7 +54,10 @@ class Cleanup(BrowserView):
             problems += self.remove_without_object(catalog_id)
             if catalog_id == 'reference_catalog':
                 problems += self.check_references()
-            problems += self.non_unique_uids(catalog_id)
+            else:
+                # Non unique ids seem persistent in the reference catalog.
+                # Running the code several times keeps creating new uids.
+                problems += self.non_unique_uids(catalog_id)
             self.msg("%s: total problems: %d", catalog_id, problems)
 
         self.newline()


### PR DESCRIPTION
It looks like it is normal there.  At least, on one Plone 4.3 site
the code keeps creating several new uids every time I run it.