### PR TITLE
Ignore non existing catalogs.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Ignore non existing catalogs.  Plone 5 does not always have
+  a ``uid_catalog`` or ``reference_catalog``.
+  Fixes `issue #5 <https://github.com/collective/collective.catalogcleanup/issues/5>`_.
+  [maurits]
 
 
 1.7 (2017-03-03)
@@ -24,7 +27,7 @@ Changelog
 ----------------
 
 - Do not complain about brains in uid_catalog that are references.
-  When their path points to `...at_references/<uid of brain>` then
+  When their path points to ``...at_references/<uid of brain>`` then
   this is normal.  I started wondering about a site that had more than
   20 thousand problems reported this way.  [maurits]
 

--- a/collective/catalogcleanup/browser.py
+++ b/collective/catalogcleanup/browser.py
@@ -48,10 +48,14 @@ class Cleanup(BrowserView):
             self.msg('dry_run SELECTED, SO ONLY REPORTING. To make changes '
                      'permanent, add "?dry_run=false" to the URL.')
             self.newline()
+        context = aq_inner(self.context)
         catalog_ids = ['portal_catalog', 'uid_catalog', 'reference_catalog']
         for catalog_id in catalog_ids:
             problems = 0
             self.newline()
+            if getToolByName(context, catalog_id, None) is None:
+                self.msg('Ignored non existing catalog %s.', catalog_id)
+                continue
             self.msg('Handling catalog %s.', catalog_id)
             problems += self.report(catalog_id)
             problems += self.remove_without_uids(catalog_id)


### PR DESCRIPTION
Plone 5 does not always have a `uid_catalog` or `reference_catalog`.

Fixes issue #5.