### PR TITLE
Disable CSRF protection.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,13 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Disable CSRF protection.
+  Fixes `issue #17 <https://github.com/collective/collective.catalogcleanup/issues/17>`_.
+  [maurits]
+
+- Abort any transaction changes in dry run mode.
+  There should not be any changes here anyway, but this makes sure.
+  [maurits]
 
 
 1.8.0 (2018-04-30)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -31,7 +31,10 @@ flake8-max-complexity = 20
 collective.noindexing = 1.2
 # use latest version of coverage
 coverage =
+plone.protect = 3.0.26
 
+[instance]
+eggs += plone4.csrffixes
 
 [plone3versions]
 <= versions

--- a/collective/catalogcleanup/testing.py
+++ b/collective/catalogcleanup/testing.py
@@ -3,11 +3,12 @@
 
 For Plone 5 we need to install plone.app.contenttypes.
 """
-from plone.app.testing import IntegrationTesting
+from plone.app.testing import FunctionalTesting
 from plone.app.testing import PloneSandboxLayer
 from zope.component import getMultiAdapter
 
 import pkg_resources
+import transaction
 
 
 try:
@@ -29,7 +30,7 @@ class CatalogCleanupLayer(PloneSandboxLayer):
 
 
 CATALOG_CLEANUP_FIXTURE = CatalogCleanupLayer()
-CATALOG_CLEANUP_INTEGRATION_TESTING = IntegrationTesting(
+CATALOG_CLEANUP_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(CATALOG_CLEANUP_FIXTURE,), name='CatalogCleanup:Integration')
 
 # A few helper functions.
@@ -40,6 +41,7 @@ def make_test_doc(portal):
     portal.invokeFactory('Document', new_id)
     doc = portal[new_id]
     doc.reindexObject()  # Might have already happened, but let's be sure.
+    transaction.commit()
     return doc
 
 

--- a/collective/catalogcleanup/tests/test_functional.py
+++ b/collective/catalogcleanup/tests/test_functional.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from collective.catalogcleanup.testing import CATALOG_CLEANUP_INTEGRATION_TESTING  # noqa: E501
+from collective.catalogcleanup.testing import CATALOG_CLEANUP_FUNCTIONAL_TESTING  # noqa: E501
 from collective.catalogcleanup.testing import cleanup
 from collective.catalogcleanup.testing import make_test_doc
 from collective.noindexing import patches
@@ -7,12 +7,13 @@ from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from Products.CMFCore.utils import getToolByName
 
+import transaction
 import unittest
 
 
 class TestCatalogCleanup(unittest.TestCase):
 
-    layer = CATALOG_CLEANUP_INTEGRATION_TESTING
+    layer = CATALOG_CLEANUP_FUNCTIONAL_TESTING
 
     def _makeOne(self):
         return make_test_doc(self.layer['portal'])
@@ -23,6 +24,7 @@ class TestCatalogCleanup(unittest.TestCase):
         patches.apply()
         portal._delObject(doc.getId())
         patches.unapply()
+        transaction.commit()
 
     def testNormalDeletedDocument(self):
         # No tricks here, just testing some assumptions.
@@ -33,6 +35,7 @@ class TestCatalogCleanup(unittest.TestCase):
         doc = self._makeOne()
         self.assertEqual(len(catalog.searchResults({})), base_count + 1)
         portal._delObject(doc.getId())
+        transaction.commit()
         self.assertEqual(len(catalog.searchResults({})), base_count)
         cleanup(portal)
         self.assertEqual(len(catalog.searchResults({})), base_count)
@@ -48,7 +51,7 @@ class TestCatalogCleanup(unittest.TestCase):
         # it is removed:
         self._delete_object_only(doc)
         self.assertEqual(len(catalog.searchResults({})), base_count + 1)
-        # By default dry_run in selected to nothing is changed.
+        # By default dry_run is selected, so nothing is changed.
         cleanup(portal)
         self.assertEqual(len(catalog.searchResults({})), base_count + 1)
         # None of these variants should have any lasting effect.


### PR DESCRIPTION
Fixes issue #17.

Also abort any transaction changes in dry run mode. There should not be any changes here anyway, but this makes sure.

It might be nicer to let our main view use a template that outputs html, so that we can create a small form which includes the csrf protection authenticator. Then we can run our code only on POST, which is better anyway. But it would have to be a simple html not inheriting from the `main_template.pt`, because I expect this package to be mainly used right before a large Plone migration, where the main_template may not yet work because you haven't done the migration yet.
Should be fairly straightforward, but I leave it as an exercise for the reader for now. :-)