### PR TITLE
Catch TypeError when getting object for brain.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Catch TypeError when getting object for brain.
+  Can happen when an object that used to be referenceable is no longer referenceable.
+  Fixes `issue #19 <https://github.com/collective/collective.catalogcleanup/issues/19>`_.
+  [maurits]
 
 
 1.8.0 (2018-04-30)

--- a/collective/catalogcleanup/browser.py
+++ b/collective/catalogcleanup/browser.py
@@ -343,6 +343,11 @@ class Cleanup(BrowserView):
             raise
         except (NotFound, AttributeError, KeyError):
             return 'notfound'
+        except TypeError:
+            logger.warning(
+                'TypeError, returning notfound for brain at %s.',
+                brain_id, exc_info=1)
+            return 'notfound'
         except:  # noqa: B901
             logger.exception('Cannot handle brain at %s.', brain_id)
             raise


### PR DESCRIPTION
Can happen when an object that used to be referenceable is no longer referenceable.
The reference in the catalog will be removed.
Fixes issue #19.